### PR TITLE
allow for new versioning of ext-json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     },
     "require": {
         "php": "^7.1",
-        "ext-json": "^1.5",
+        "ext-json": "^1.5 || ^7.4",
         "symfony/http-client": "^4.3"
     },
     "require-dev": {


### PR DESCRIPTION
ext-json has a different versioning schema since [php 7.4](https://github.com/php/php-src/pull/4459).
constraining to 1.5 does not allow for php 7.4.